### PR TITLE
Add node_modules to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/img/.DS_Store
 src/.DS_Store
 public/.DS_Store
 .DS_Store
+node_modules


### PR DESCRIPTION
Adds the `node_modules` directory to ignore list in the git repository. Dependencies shouldn't be version controlled.