### PR TITLE
[Fix] - Remove URL location on airport pullout closure

### DIFF
--- a/public/js/simaware_app/simaware-airport.js
+++ b/public/js/simaware_app/simaware-airport.js
@@ -85,6 +85,7 @@ function returnFromAirport()
     {
         map.addLayer(plane_featuregroup);
     }
+    window.history.pushState('home', 'home', '/');
     $('#airport-sidebar').hide();
 }
 


### PR DESCRIPTION
When closing `control-airport-pullout` this will set the URL to the correct state