### PR TITLE
feat: Added links from flight overlay to the airports

### DIFF
--- a/public/css/simawaremap.css
+++ b/public/css/simawaremap.css
@@ -177,6 +177,23 @@ a
 {
   font-size: 0.75rem;
 }
+.flights-link-item
+{
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  padding: 2px;
+  margin-left: -3px;
+  cursor: pointer;
+}
+.flights-link-item:hover
+{
+  background-color: rgba(0,0,0,0.15);
+  border: 1px solid #222;
+}
+.flights-link-item:active
+{
+  background-color: rgba(0,0,0,0.25);
+}
 .leaflet-container
 {
   background-color: #000 !important;

--- a/public/js/simaware_app/simaware-map.js
+++ b/public/js/simaware_app/simaware-map.js
@@ -2100,8 +2100,11 @@ function updateFlightsBox(flight)
     [dep_airport, dep_point_, dep_name, dep_city] = processAirport(plane.flight.dep);
     [arr_airport, arr_point_, arr_name, arr_city] = processAirport(plane.flight.arr);
 
-    $('#flights-dep-icao').html(dep_airport); $('#flights-airport-dep').html('<div class="flights-link-item" onclick="zoomToAirport(\''+dep_airport+'\')">'+dep_name+'<br><span class="text-muted">'+dep_city+'</span></div>');
-    $('#flights-arr-icao').html(arr_airport); $('#flights-airport-arr').html('<div class="flights-link-item" onclick="zoomToAirport(\''+arr_airport+'\')">'+arr_name+'<br><span class="text-muted">'+arr_city+'</span></div>');
+    $('#flights-dep-icao').html('<div class="flights-link-item" onclick="zoomToAirport(\''+dep_airport+'\')">'+dep_airport+'</div>');
+    $('#flights-airport-dep').html('<div class="flights-link-item" onclick="zoomToAirport(\''+dep_airport+'\')">'+dep_name+'<br><span class="text-muted">'+dep_city+'</span></div>');
+    
+    $('#flights-arr-icao').html('<div class="flights-link-item" onclick="zoomToAirport(\''+arr_airport+'\')">'+arr_airport+'</div>');
+    $('#flights-airport-arr').html('<div class="flights-link-item" onclick="zoomToAirport(\''+arr_airport+'\')">'+arr_name+'<br><span class="text-muted">'+arr_city+'</span></div>');
 
     // Set the progress bar correctly
     $('#flights-progressbar-elapsed').css({ width: getElapsedWidth(flight) + '%' });

--- a/public/js/simaware_app/simaware-map.js
+++ b/public/js/simaware_app/simaware-map.js
@@ -2100,8 +2100,8 @@ function updateFlightsBox(flight)
     [dep_airport, dep_point_, dep_name, dep_city] = processAirport(plane.flight.dep);
     [arr_airport, arr_point_, arr_name, arr_city] = processAirport(plane.flight.arr);
 
-    $('#flights-dep-icao').html(dep_airport); $('#flights-airport-dep').html(dep_name+'<br><span class="text-muted">'+dep_city+'</span>');
-    $('#flights-arr-icao').html(arr_airport); $('#flights-airport-arr').html(arr_name+'<br><span class="text-muted">'+arr_city+'</span>');
+    $('#flights-dep-icao').html(dep_airport); $('#flights-airport-dep').html('<div class="flights-link-item" onclick="zoomToAirport(\''+dep_airport+'\')">'+dep_name+'<br><span class="text-muted">'+dep_city+'</span></div>');
+    $('#flights-arr-icao').html(arr_airport); $('#flights-airport-arr').html('<div class="flights-link-item" onclick="zoomToAirport(\''+arr_airport+'\')">'+arr_name+'<br><span class="text-muted">'+arr_city+'</span></div>');
 
     // Set the progress bar correctly
     $('#flights-progressbar-elapsed').css({ width: getElapsedWidth(flight) + '%' });


### PR DESCRIPTION
I've linked each depature and arrival airport in the flights overlay with the respective view of the airport.

The reason for that is that sometimes you may want to have a look at the airports depatures and arrivals you are flying from or to even if there is no event or atc online.

This makes that easier instead of searching for the airport.