### PR TITLE
Interpret Sweden FIR ATIS letter

### DIFF
--- a/public/js/simaware_app/simaware-atis.js
+++ b/public/js/simaware_app/simaware-atis.js
@@ -6,7 +6,8 @@ function getAtisCode(atis, icao)
   delete code;
   $.each(atis_exploded, function(idx, char)
   {
-    if(char == 'INFO' || char == 'INFORMATION')
+    if(char == 'INFO' || char == 'INFORMATION'
+       || (char == 'ATIS' && atis_exploded[idx-1] == icao && atis_exploded[idx+1] != 'INFO' && atis_exploded[idx+1] != 'INFORMATION'))
     {
       code = atis_exploded[idx + 1];
       return false;


### PR DESCRIPTION
Hi (again),

Sweden FIR writes their ATISes very short, like "ESSA ATIS K. TIME xxxx." The current code assumes there's an "INFO" or "INFORMATION" before the ATIS letter. This PR makes SimAware interpret swedish ATIS with the correct letter.

Thanks again,
Martin
