### PR TITLE
added removeClass func to toggleATC

### DIFF
--- a/src/js/simaware_app/simaware-map.js
+++ b/src/js/simaware_app/simaware-map.js
@@ -2468,6 +2468,7 @@ async function toggleATC()
     if(map.hasLayer(atc_featuregroup) && atc_featuregroup.hasLayer(atc_leg_featuregroup))
     {
         map.removeLayer(atc_featuregroup);
+        $('.map-button#atc').removeClass('map-button-active');
         $('.map-button#layers').removeClass('map-button-active');
         $.cookie('layers', 'false', {expires: 180});
     }


### PR DESCRIPTION
On the current build, the ATC button is always active once clicked for the first time by the users.
There was a removeClass call for the class, so it was added to this PR.