### PR TITLE
Added Aircraft Icon for PA24 (#97)

### DIFF
--- a/src/js/simaware_app/simaware-map.js
+++ b/src/js/simaware_app/simaware-map.js
@@ -2849,6 +2849,7 @@ function getMarker(str)
     case 'PA28S':
     case 'PA28T':
     case 'PA28U':
+    case 'PA24':
         return [28, 22, 'PA28x'];
     case 'SB20':
         return [27, 30, 'SB20'];


### PR DESCRIPTION
Added PA24 to the PA28, because they are quite similar. Maybe there could be a custom icon for the PA24 at some point.

https://github.com/maiuswong/simaware-express/issues/97