### PR TITLE
fix(regprefixes): remove Liechtenstein

### DIFF
--- a/public/livedata/regprefixes.json
+++ b/public/livedata/regprefixes.json
@@ -104,7 +104,6 @@
     {"country":"Lesotho","regex":"^7P[A-Z][A-Z][A-Z]\\b"},
     {"country":"Liberia","regex":"^A8[A-Z][A-Z][A-Z]\\b"},
     {"country":"Libya","regex":"^5A[A-Z][A-Z][A-Z]\\b"},
-    {"country":"Liechtenstein","regex":"^HB[A-Z][A-Z][A-Z]\\b"},
     {"country":"Lithuania","regex":"^LY[A-Z][A-Z][A-Z]\\b"},
     {"country":"Luxembourg","regex":"^LX[A-Z][A-Z][A-Z]\\b"},
     {"country":"Macau","regex":"^BM[A-Z][A-Z]\\b"},


### PR DESCRIPTION
Since Liechtenstein is not a registered ICAO country, planes registered within Liechtenstein are registered with HB-XXX (Switzerland) registrations.

Because the majority of planes using the HB-XXX registration are Swiss, it would be better to display the HB-XXX registrations as Swiss only, instead of including both countries in the list.